### PR TITLE
[ci skip] use bot.inspection = disabled

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -5,4 +5,4 @@ conda_forge_output_validation: true
 conda_build:
   pkg_format: '2'
 bot: 
-  inspection: false
+  inspection: disabled


### PR DESCRIPTION
conda-forge migrates to using "disabled" instead of False as an option for bot.inspection.
https://github.com/regro/cf-scripts/issues/2272#issuecomment-2004119968

@beckermr

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
